### PR TITLE
fix line ending: on my windows machine it fails on \r

### DIFF
--- a/grammar/parser.js
+++ b/grammar/parser.js
@@ -49,7 +49,9 @@ function parse(code){
 					// console.log("Parse succesful: \n", util.inspect(parser.results[0], { depth: 10}), "\n");
 				}
 				// build the tokenized syntax tree
-				ast['@main'].push(parser.results[0]);
+				if(parser.results[0] != undefined){
+					ast['@main'].push(parser.results[0]);
+				}
 			} catch (e) {
 				console.log("!!! Parse failed: \n", e.message);
 				// console.log("Interpreted as comment:", { '@comment': parser.lexer.buffer });

--- a/grammar/parser.js
+++ b/grammar/parser.js
@@ -26,6 +26,11 @@ function parse(code){
 		let parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 		if (lines[l] !== ''){			
 			try {
+				//fix line ending, if needed
+				if(lines[l].at(-1) == '\r'){
+					lines[l] = lines[l].slice(0, -1);
+				}
+
 				// parse something!
 				parser.feed(lines[l]);
 


### PR DESCRIPTION
I must be the only guy in the world playing around with your project on a windows system :).. 

running 'npm run test' fails on every line...

I expect this nearly parser can provide lines without the trailing \r, if so that would be the better way of fixing it... I wouldn't know where to start finding that solution, so here is my fix...

cheers.